### PR TITLE
oldest-supported-numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "Cython",
-    "numpy",
+    "oldest-supported-numpy",
     "setuptools>=42",
     "wheel",
     "build",


### PR DESCRIPTION
This solves a lot of numpy version dependency issues, as the numpy - C api can have some issues with different versions of python.

It might not matter here until numba updates its python version requirements, but it's good practice for long-term maintenance.

It can help prevent the root cause of this issue: https://iq.opengenus.org/module-compiled-against-api-version-0x10-but-this-version-of-numpy-is-0xe/

Oldest supported numpy: https://pypi.org/project/oldest-supported-numpy/