### PR TITLE
Update supported Numpy and Python versions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "<3.12"
+        python-version: "<3.13"
     # Build source
     - name: Install pypa/build
       run: >-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = ['figaro', 'figaro._pipelines']
 name = 'figaro'
 description = 'FIGARO: Fast Inference for GW Astronomy, Research & Observations'
 version = '1.7.2'
-requires-python = '< 3.12'
+requires-python = '>= 3.9, < 3.13'
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
 keywords = ['DPGMM', 'HDPGMM', 'figaro', 'hierarchical', 'inference']
@@ -29,18 +29,16 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.6",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   'Topic :: Scientific/Engineering :: Astronomy',
   'Topic :: Scientific/Engineering :: Physics',
 ]
 
 dependencies = [
-    "numpy > 1.22, < 2",
+    "numpy > 1.22, < 2.2",
     "scipy",
     "matplotlib != 3.6.3",
     "dill",


### PR DESCRIPTION
- Add support for Python 3.12 and 3.13
- Drop support for EOL Python versions 3.6, 3.7, and 3.8
- Add support for Numpy >= 1.22, including Numpy 2.x