### PR TITLE
Remove Numpy version upper limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "numpy > 1.22, < 2.2",
+    "numpy > 1.22",
     "scipy",
     "matplotlib != 3.6.3",
     "dill",


### PR DESCRIPTION
Numba _does_ now support Numpy 2.2.x. Also, Numba itself states in its project metadata the upper limit for the Numpy version, so there is no reason to do a new release of FIGARO every time that Numba increases the Numpy version that it supports.