### PR TITLE
Remove unnecessary buid system requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,6 @@
 [build-system]
 requires = [
-    "oldest-supported-numpy",
     "setuptools>=42",
-    "wheel",
-    "build",
     ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
- Remove oldest-supported-numpy because this is a pure Python package and has no build time requirement on Numpy. Also, oldest-supported-numpy is obsolete.
- Remove dependencies on build and wheel because these no longer need to be specified explicitly.